### PR TITLE
Fixed infinite loop bug in Subgraph isomorphism (#1672)

### DIFF
--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/matching.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/matching.hpp
@@ -457,7 +457,6 @@ solution<Cpu> engine_bundle<Cpu>::run() {
     std::uint64_t max_threads_count = dal::detail::threader_get_max_threads();
     std::uint64_t possible_first_states_count_per_thread = first_states_count / max_threads_count;
     if (possible_first_states_count_per_thread < 1) {
-        max_threads_count = first_states_count;
         possible_first_states_count_per_thread = 1;
     }
     else {
@@ -465,7 +464,11 @@ solution<Cpu> engine_bundle<Cpu>::run() {
             static_cast<bool>(first_states_count % max_threads_count);
     }
 
-    const std::uint64_t array_size = max_threads_count;
+    const std::uint64_t array_size = (max_threads_count >= 64)   ? max_threads_count * 2 / 10
+                                     : (max_threads_count >= 24) ? max_threads_count * 4 / 10
+                                     : (max_threads_count >= 8)  ? 4
+                                     : (max_threads_count >= 4)  ? 2
+                                                                 : 1;
     auto engine_array_ptr = allocator_.make_shared_memory<matching_engine<Cpu>>(array_size);
     matching_engine<Cpu>* engine_array = engine_array_ptr.get();
 


### PR DESCRIPTION
* Experiment to address infinite loop

* Experiment #2 to address infinite loop

* Experiment #3 to address infinite loop

* Temporary debug output added

* External limit for number of threads was removed

* Experiment #4 to address infinite loop

* Experiment #5 to address infinite loop

* Experiment #6 to address infinite loop

* Experiment #7 to address infinite loop

* Experiment #8 to address infinite loop

* 20% is set as optimal value

* Temporary code removed

* Optimal array_size is caclulated based on max thread count

* Optimal array_size is decreased

* Optimal array_size is adjusted

* Optimal array_size is adjusted

* Optimal array_size is adjusted

* Optimal array_size is adjusted

* Optimal array_size is adjusted

* Optimal array_size is adjusted

* Optimal array_size is adjusted

* Experiment #9 to address infinite loop

* Optimal array_size is adjusted

* Temporary debug output added

* Compilation fix

* Experiment #10 to address infinite loop

* Temporary debug output added

* Experiment #11 to address infinite loop

* Temporary code removed

* Optimal array_size is adjusted

# Description
Please include a summary of the change. For large or complex changes please include enough information to introduce your change and explain motivation for it.

Changes proposed in this pull request:
-
-
-