### PR TITLE
atomic linking removal from examples + actualization of dal.hpp (#1703)

### DIFF
--- a/cpp/oneapi/dal.hpp
+++ b/cpp/oneapi/dal.hpp
@@ -32,10 +32,10 @@
 #include "oneapi/dal/table/column_accessor.hpp"
 
 /* Graphs */
-#include "oneapi/dal/graph/graph_common.hpp"
+#include "oneapi/dal/graph/common.hpp"
 #include "oneapi/dal/graph/service_functions.hpp"
-#include "oneapi/dal/graph/undirected_adjacency_array_graph.hpp"
-#include "oneapi/dal/graph/directed_adjacency_array_graph.hpp"
+#include "oneapi/dal/graph/undirected_adjacency_vector_graph.hpp"
+#include "oneapi/dal/graph/directed_adjacency_vector_graph.hpp"
 
 /* I/O */
 #include "oneapi/dal/io/csv.hpp"

--- a/examples/oneapi/cpp/makefile_lnx
+++ b/examples/oneapi/cpp/makefile_lnx
@@ -120,7 +120,6 @@ LIBS := $(onedal) \
         -ltbbmalloc \
         -lpthread \
         -ldl \
-        -latomic
 
 LOPTS := -L"$(DAAL_PATH)" \
          -L"$(TBB_PATH)" \


### PR DESCRIPTION
* fixed clear code

* inital version of implenting new graph structure

* Graph with raw ptr + example in service function

* raw ptr are wrapped into array

* graph service functions

* added inline specifier

* Load graph is now mix of allocating+comute_call. Currently, no instances of compute calls in cpp.

* calls from lib for int32_t + array->graph_container

* adapted jaccard for int32 with previous optimization + general code in hpp for other types

* fixes for review

* Part of changes accroding to Andrey's comments.

* changed naming of vars in graph constructor

* another part of Andrey's comments: moved edge list related things, vertex,edge values are wrappers instead of structs

* added return type for inner service.

* service adoption + small fixes

* changed csr arrays naming to rows, cols

* copy constructor is moved to private + fixes of functions names

* not used funcs were removed

* removed std vector from loading edge list. created custom vector based on dal array.

* fixes for vector + small comments were adressed

* file separation for Jaccard algo.

* restructured jaccard detail files + fixes for vector_container

* fix of a bug for reserve

* backend base now full virtual

* 2020 -> 2020-2021

* removed int64 example + vector_container  fixes

* fixed table include

* size_t->int64_t + removed unused var in load graph

* removed unnesseasry casts

* added std::

* fix win example export

* removed unused onedal export

* win fix

* revert last commit

* changed vector_container to store count instead of capacity and set capacity as field count of array

* removed unused methods + fixed naming

* try to fix bazel build

* fix of multiple def load edge list

* fixed include of daal in load graph

* fixed include daal

* remove unused instances in threading

* fix of bazel

* Initial support of Triangle Counting

* Add example and fix build issues

* Add Global TC implementation for AVX512 (no relabel)

* Add support of 64-bit offsets + fix Global TC overflow issue

* Fixed issue with relabel

* Add local TC scalar branch + threading dependencies

* allocator support

* clang format

* Add vectorized code branch for Local TC

* Fixed issue with relabel parameter

* allocator + hpp kernel dive in cpp for tc and rebuild

* Applied clang-format and clear_code

* fixed clear code

* Fix merge issues

* Clang format + removed some debug info

* Fix issue with Global TC relabel code branch

* support for other index types in TC

* added support for other ISA beside avx512 for TC. Temp file separation

* clang format

* Fixed parallel reduce

* replace of reduce sizet to int32 and scalar intersection to return int32

* Fix relabel issue

* Fix clang

* added local_and_global tc kernel

* removed couts

* fixed service functions

* added dispatching in io graph + wrap for allocator

* removed useless includes

* removed v1

* removed extra includes

* renamed kernels

* added const where it  is needed

* removed explicit inst. of forceinline funcs in backend

* fixed ns in backend and changed names of backend kernels for shorter

* Introduced ONEDAL_FORCEINLINE and removed extra export in threading

* more compact ns

* descriptor private field  for asserts + getter are inheritated

* select kernel fixes

* bazel fix

* clang format

* fix of enable if task

* clang

* removed extra examples

* changed examples lst

* fixed misstype for allocate

* example prepared. i do not  like it

* fix v1, no v1 no

* Fixed Bazel tests build

* Fixed mistype in types

* Replaced std::min with own min to fix issue on Windows

* Fixed clang

* Fixed link issue on windows

* Fixed link issues on Windows

* SDL for allocator

* Fixed warnings on windows

* Fixed mistype

* Fixed mistypes in threading

* Renamed example to fix the issue on Windows

* Renamed example + excluded graph examples from windows

* Fixed link issues on Windows

* Exclude TC from windows due to load_graph issue

* Fix clear_code

* Fixed exports

* Return back nmake examples

* Returned exports removed by mistake

* Fixed KW issues for TC

* Fix warning for MSVC compiler (#1695)

* NuSVM Docs (#1679)

* NuSVM docs

* Comments applied

* NuSVR formulas fix

* Update docs/source/onedal/algorithms/svm/svm.rst

Co-authored-by: Kirill <kirill.petrov@intel.com>

* Comments applied

* NuSVR formula fix

* Typo fix

Co-authored-by: Kirill <kirill.petrov@intel.com>

* Edge count fix (#1698)

* fixed clear code

* inital version of implenting new graph structure

* Graph with raw ptr + example in service function

* raw ptr are wrapped into array

* graph service functions

* added inline specifier

* Load graph is now mix of allocating+comute_call. Currently, no instances of compute calls in cpp.

* calls from lib for int32_t + array->graph_container

* adapted jaccard for int32 with previous optimization + general code in hpp for other types

* fixes for review

* Part of changes accroding to Andrey's comments.

* changed naming of vars in graph constructor

* another part of Andrey's comments: moved edge list related things, vertex,edge values are wrappers instead of structs

* added return type for inner service.

* service adoption + small fixes

* changed csr arrays naming to rows, cols

* copy constructor is moved to private + fixes of functions names

* not used funcs were removed

* removed std vector from loading edge list. created custom vector based on dal array.

* fixes for vector + small comments were adressed

* file separation for Jaccard algo.

* restructured jaccard detail files + fixes for vector_container

* fix of a bug for reserve

* backend base now full virtual

* 2020 -> 2020-2021

* removed int64 example + vector_container  fixes

* fixed table include

* size_t->int64_t + removed unused var in load graph

* removed unnesseasry casts

* added std::

* fix win example export

* removed unused onedal export

* win fix

* revert last commit

* changed vector_container to store count instead of capacity and set capacity as field count of array

* removed unused methods + fixed naming

* try to fix bazel build

* fix of multiple def load edge list

* fixed include of daal in load graph

* fixed include daal

* remove unused instances in threading

* fix of bazel

* Initial support of Triangle Counting

* Add example and fix build issues

* Add Global TC implementation for AVX512 (no relabel)

* Add support of 64-bit offsets + fix Global TC overflow issue

* Fixed issue with relabel

* Add local TC scalar branch + threading dependencies

* allocator support

* clang format

* Add vectorized code branch for Local TC

* Fixed issue with relabel parameter

* allocator + hpp kernel dive in cpp for tc and rebuild

* Applied clang-format and clear_code

* fixed clear code

* Fix merge issues

* Clang format + removed some debug info

* Fix issue with Global TC relabel code branch

* support for other index types in TC

* added support for other ISA beside avx512 for TC. Temp file separation

* clang format

* Fixed parallel reduce

* replace of reduce sizet to int32 and scalar intersection to return int32

* Fix relabel issue

* Fix clang

* added local_and_global tc kernel

* removed couts

* fixed service functions

* added dispatching in io graph + wrap for allocator

* removed useless includes

* removed v1

* removed extra includes

* renamed kernels

* added const where it  is needed

* removed explicit inst. of forceinline funcs in backend

* fixed ns in backend and changed names of backend kernels for shorter

* Introduced ONEDAL_FORCEINLINE and removed extra export in threading

* more compact ns

* descriptor private field  for asserts + getter are inheritated

* select kernel fixes

* bazel fix

* clang format

* fix of enable if task

* clang

* removed extra examples

* changed examples lst

* fixed misstype for allocate

* example prepared. i do not  like it

* fix v1, no v1 no

* Fixed Bazel tests build

* Fixed mistype in types

* Replaced std::min with own min to fix issue on Windows

* Fixed clang

* Fixed link issue on windows

* Fixed link issues on Windows

* SDL for allocator

* Fixed warnings on windows

* Fixed mistype

* Fixed mistypes in threading

* Renamed example to fix the issue on Windows

* Renamed example + excluded graph examples from windows

* Fixed link issues on Windows

* Exclude TC from windows due to load_graph issue

* Fix clear_code

* Fixed exports

* Return back nmake examples

* Returned exports removed by mistake

* Fixed KW issues for TC

* fixed invalid count for edges

Co-authored-by: bysheva <tatyana.bysheva@intel.com>

* update master (#25)

* Fix warning for MSVC compiler (#1695)

* NuSVM Docs (#1679)

* NuSVM docs

* Comments applied

* NuSVR formulas fix

* Update docs/source/onedal/algorithms/svm/svm.rst

Co-authored-by: Kirill <kirill.petrov@intel.com>

* Comments applied

* NuSVR formula fix

* Typo fix

Co-authored-by: Kirill <kirill.petrov@intel.com>

* Edge count fix (#1698)

* fixed clear code

* inital version of implenting new graph structure

* Graph with raw ptr + example in service function

* raw ptr are wrapped into array

* graph service functions

* added inline specifier

* Load graph is now mix of allocating+comute_call. Currently, no instances of compute calls in cpp.

* calls from lib for int32_t + array->graph_container

* adapted jaccard for int32 with previous optimization + general code in hpp for other types

* fixes for review

* Part of changes accroding to Andrey's comments.

* changed naming of vars in graph constructor

* another part of Andrey's comments: moved edge list related things, vertex,edge values are wrappers instead of structs

* added return type for inner service.

* service adoption + small fixes

* changed csr arrays naming to rows, cols

* copy constructor is moved to private + fixes of functions names

* not used funcs were removed

* removed std vector from loading edge list. created custom vector based on dal array.

* fixes for vector + small comments were adressed

* file separation for Jaccard algo.

* restructured jaccard detail files + fixes for vector_container

* fix of a bug for reserve

* backend base now full virtual

* 2020 -> 2020-2021

* removed int64 example + vector_container  fixes

* fixed table include

* size_t->int64_t + removed unused var in load graph

* removed unnesseasry casts

* added std::

* fix win example export

* removed unused onedal export

* win fix

* revert last commit

* changed vector_container to store count instead of capacity and set capacity as field count of array

* removed unused methods + fixed naming

* try to fix bazel build

* fix of multiple def load edge list

* fixed include of daal in load graph

* fixed include daal

* remove unused instances in threading

* fix of bazel

* Initial support of Triangle Counting

* Add example and fix build issues

* Add Global TC implementation for AVX512 (no relabel)

* Add support of 64-bit offsets + fix Global TC overflow issue

* Fixed issue with relabel

* Add local TC scalar branch + threading dependencies

* allocator support

* clang format

* Add vectorized code branch for Local TC

* Fixed issue with relabel parameter

* allocator + hpp kernel dive in cpp for tc and rebuild

* Applied clang-format and clear_code

* fixed clear code

* Fix merge issues

* Clang format + removed some debug info

* Fix issue with Global TC relabel code branch

* support for other index types in TC

* added support for other ISA beside avx512 for TC. Temp file separation

* clang format

* Fixed parallel reduce

* replace of reduce sizet to int32 and scalar intersection to return int32

* Fix relabel issue

* Fix clang

* added local_and_global tc kernel

* removed couts

* fixed service functions

* added dispatching in io graph + wrap for allocator

* removed useless includes

* removed v1

* removed extra includes

* renamed kernels

* added const where it  is needed

* removed explicit inst. of forceinline funcs in backend

* fixed ns in backend and changed names of backend kernels for shorter

* Introduced ONEDAL_FORCEINLINE and removed extra export in threading

* more compact ns

* descriptor private field  for asserts + getter are inheritated

* select kernel fixes

* bazel fix

* clang format

* fix of enable if task

* clang

* removed extra examples

* changed examples lst

* fixed misstype for allocate

* example prepared. i do not  like it

* fix v1, no v1 no

* Fixed Bazel tests build

* Fixed mistype in types

* Replaced std::min with own min to fix issue on Windows

* Fixed clang

* Fixed link issue on windows

* Fixed link issues on Windows

* SDL for allocator

* Fixed warnings on windows

* Fixed mistype

* Fixed mistypes in threading

* Renamed example to fix the issue on Windows

* Renamed example + excluded graph examples from windows

* Fixed link issues on Windows

* Exclude TC from windows due to load_graph issue

* Fix clear_code

* Fixed exports

* Return back nmake examples

* Returned exports removed by mistake

* Fixed KW issues for TC

* fixed invalid count for edges

Co-authored-by: bysheva <tatyana.bysheva@intel.com>

Co-authored-by: Pavel Yakovlev <pavel.yakovlev@intel.com>
Co-authored-by: Nikita Timakin <nikita.timakin@intel.com>
Co-authored-by: Kirill <kirill.petrov@intel.com>
Co-authored-by: bysheva <tatyana.bysheva@intel.com>

* removed latomic from makefile

* update dal.hpp for actual graph headers

Co-authored-by: bysheva <tatyana.bysheva@intel.com>
Co-authored-by: Pavel Yakovlev <pavel.yakovlev@intel.com>
Co-authored-by: Nikita Timakin <nikita.timakin@intel.com>
Co-authored-by: Kirill <kirill.petrov@intel.com>

# Description
Please include a summary of the change. For large or complex changes please include enough information to introduce your change and explain motivation for it.

Changes proposed in this pull request:
-
-
-